### PR TITLE
Change "ReCharge Voltage" from default to optional

### DIFF
--- a/power_service.json
+++ b/power_service.json
@@ -113,7 +113,7 @@
       "id": 9,
       "name": "ReCharge Voltage",
       "type": "ReChargeVoltages",
-      "default": "ReChargeVoltages::PERCENT_97_6"
+      "optional": true
     }
   ],
   "enums": [


### PR DESCRIPTION
`ReCharge Voltage` needs to be `optional` instead of `default` to support robot default settings