### PR TITLE
Add parameter Dangerously Override Hardware Current Limit

### DIFF
--- a/power_service.json
+++ b/power_service.json
@@ -114,6 +114,12 @@
       "name": "ReCharge Voltage",
       "type": "ReChargeVoltages",
       "default": "ReChargeVoltages::PERCENT_97_6"
+    },
+    {
+      "id": 10,
+      "name": "Dangerously Override Hardware Current Limit",
+      "type": "uint8_t",
+      "optional": true
     }
   ],
   "enums": [


### PR DESCRIPTION
This parameter should make it possible voor V2 hardware users to set the Charge Current to a value that might endanger hardware. By default, the Charge Current is max 1A.

Adding
` /ll/services/power/dangerously_override_hardware_current_limit: true
`in mower_params.yaml overrides this maximum.

This parameter requires changes in 3 repositories. The pull requests all have the same name.

### https://github.com/xtech/definitions-open-mower

Definitions-open-mower is used by fw-openmower-v2 and by
open_mower_ros. At testing time, they used an older version, commit
services @ dad32a9

This pull request adds the definition of
  "Dangerously Override Hardware Current Limit"

### https://github.com/xtech/fw-openmower-v2

This pull request adds reading the optional value of
 "Dangerously Override Hardware Current Limit" from ROS.
If set, it will allow higher Charge Currents then 1A

### https://github.com/ClemensElflein/open_mower_ros

This pull request adds reading dangerously_override_hardware_current_limit
from open_mower.yaml and making it available to ROS.

### These pull requests have been tested against:

- definitions-open-mower @ dad32a9
- fw-openmower-v2 @ 3b39af2
- open_mower_ros @ da7a52a