### PR TITLE
🐛 fix(power_service): correct field name and switch register from "op…

### DIFF
--- a/power_service.json
+++ b/power_service.json
@@ -117,9 +117,9 @@
     },
     {
       "id": 10,
-      "name": "Dangerously Override Hardware Current Limit",
+      "name": "Dangerously Override Hardware Charge Current Limit",
       "type": "uint8_t",
-      "optional": true
+      "default": 0
     }
   ],
   "enums": [


### PR DESCRIPTION
…tional" to "default"

- rename field to clarify it's for charge current limit
- add default value 0 for the field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Power service register configuration updated with improved naming clarity for hardware charge current management and adjusted requirement settings with default values applied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xtech/definitions-open-mower/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->