### PR TITLE
MowerService: add mow motor direction (v2)

### DIFF
--- a/mower_service.json
+++ b/mower_service.json
@@ -2,8 +2,8 @@
   "inputs": [
     {
       "id": 0,
-      "name": "MowerEnabled",
-      "type": "uint8_t"
+      "name": "Mower Speed",
+      "type": "float"
     }
   ],
   "outputs": [
@@ -41,9 +41,24 @@
       "id": 6,
       "name": "Mower Motor RPM",
       "type": "float"
+    },
+    {
+      "id": 7,
+      "name": "Mower Motor Direction",
+      "type": "MowerDirection"
     }
   ],
   "registers": [],
+  "enums": [
+    {
+      "id": "MowerDirection",
+      "base_type": "uint8_t",
+      "values": {
+        "REVERSE": 0,
+        "FORWARD": 1
+      }
+    }
+  ],
   "type": "MowerService",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
Adds mow motor direction support for v2 hardware (MowerService protocol).

**Required together (all three):**
- xtech/definitions-open-mower#24 — protocol
- xtech/fw-openmower-v2#71 — firmware
- ClemensElflein/open_mower_ros#324 — ROS (mower_comms_v2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the mower service interface to support speed control and motor direction.
  * Added a new direction option with reverse and forward states.

* **Changes**
  * The mower service contract has been updated to version 2.
  * The existing input now accepts a speed value instead of a simple on/off signal.
  * A new output is available to report the mower motor’s direction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->