### PR TITLE
MowerService: remove redundant mow motor direction (v2)

### DIFF
--- a/mower_service.json
+++ b/mower_service.json
@@ -46,5 +46,5 @@
   "registers": [],
   "enums": [],
   "type": "MowerService",
-  "version": 3
+  "version": 2
 }

--- a/mower_service.json
+++ b/mower_service.json
@@ -41,24 +41,10 @@
       "id": 6,
       "name": "Mower Motor RPM",
       "type": "float"
-    },
-    {
-      "id": 7,
-      "name": "Mower Motor Direction",
-      "type": "MowerDirection"
     }
   ],
   "registers": [],
-  "enums": [
-    {
-      "id": "MowerDirection",
-      "base_type": "uint8_t",
-      "values": {
-        "REVERSE": 0,
-        "FORWARD": 1
-      }
-    }
-  ],
+  "enums": [],
   "type": "MowerService",
-  "version": 2
+  "version": 3
 }


### PR DESCRIPTION
Follow-up to #24.

While reviewing the firmware PR ([fw-openmower-v2#71](https://github.com/xtech/fw-openmower-v2/pull/71)), the consensus was that the separate `MowerDirection` register is redundant:

> So... I don't see a real reason for the new MowerDirection register if it could be also expressed with a negative speed

> Agreed on the direction register, it's redundant and splitting the information for no good reason, let's merge it as well and just send the speed with a sign. The app probably needs the absolute speed though

This PR does that on the protocol side:

- Remove the `Mower Motor Direction` output (id 7) and the `MowerDirection` enum.
- The sign of the existing `Mower Motor RPM` output now conveys rotation direction; consumers that need the magnitude take its absolute value.
- The commanded direction is already carried by the signed `Mower Speed` input (id 0), so no direction command register is needed either.

Version stays at 2 (nothing has been built on top of the #24 protocol yet). Firmware and ROS changes to send/consume signed RPM will follow in their respective PRs (#71 and ClemensElflein/open_mower_ros#324).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the previously defined mower direction enum from the service configuration.
  * No other service registers or public declarations were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->