### PR TITLE
Feature/collision multiple

### DIFF
--- a/emergency_service.json
+++ b/emergency_service.json
@@ -27,6 +27,7 @@
         "LIFT": 3,
         "LIFT_MULTIPLE": 4,
         "COLLISION": 5,
+        "COLLISION_MULTIPLE": 9,
         "TIMEOUT_HIGH_LEVEL": 6,
         "HIGH_LEVEL": 7,
         "SERVICE_NOT_READY": 8

--- a/input_service.json
+++ b/input_service.json
@@ -43,6 +43,12 @@
       "name": "Lift Multiple Delay",
       "type": "uint32_t",
       "default": 10
+    },
+    {
+      "id": 4,
+      "name": "Collision Multiple Delay",
+      "type": "uint32_t",
+      "default": 10
     }
   ],
   "enums": [

--- a/mower_service.json
+++ b/mower_service.json
@@ -2,8 +2,8 @@
   "inputs": [
     {
       "id": 0,
-      "name": "MowerEnabled",
-      "type": "uint8_t"
+      "name": "Mower Speed",
+      "type": "float"
     }
   ],
   "outputs": [
@@ -44,6 +44,7 @@
     }
   ],
   "registers": [],
+  "enums": [],
   "type": "MowerService",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
Added "collision" (and "collision multiple") reason in the same way as lift/lift_multiple, for SA/SC type hall sensors on outer cover.
Those should be handled differently than the lift sensors.

**THIS PR also reverted the planned but not finished `Mower Speed` / `MowerEnabled` inputs to be able to get tested**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new emergency reason for multiple-collision events.
  - Introduced a configurable “Collision Multiple Delay” setting (default: 10 seconds) for handling multiple collisions.

- **Updates**
  - Updated mower service configuration to use “Mower Speed” (floating-point value) instead of a mower-enabled status.
  - Revised mower service schema/version metadata to match the updated control format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->