### PR TITLE
Add mower RPM specifc emergencies

### DIFF
--- a/emergency_service.json
+++ b/emergency_service.json
@@ -30,7 +30,8 @@
         "COLLISION_MULTIPLE": 9,
         "TIMEOUT_HIGH_LEVEL": 6,
         "HIGH_LEVEL": 7,
-        "SERVICE_NOT_READY": 8
+        "SERVICE_NOT_READY": 8,
+        "MOWER_RPM_LIMIT": 10
       }
     }
   ]

--- a/emergency_service.json
+++ b/emergency_service.json
@@ -31,7 +31,8 @@
         "TIMEOUT_HIGH_LEVEL": 6,
         "HIGH_LEVEL": 7,
         "SERVICE_NOT_READY": 8,
-        "MOWER_RPM_LIMIT": 10
+        "MOWER_RPM_TIMEOUT": 10,
+        "MOWER_RPM_LIMIT": 11
       }
     }
   ]


### PR DESCRIPTION
- MOWER_RPM_TIMEOUT will trigger if the mower doesn't reach a configured RPM in a configured time
- MOWER_RPM_LIMIT will trigger immediately if mower RPM exceed a configured RPM limit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added emergency status reasons for mower RPM timeouts and RPM limit conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->